### PR TITLE
Add padding line before return statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,11 @@ export default await createConfigForNuxt()
             format: ['camelCase']
           }
         ],
-        '@stylistic/js/quote-props': ['error', 'as-needed']
+        '@stylistic/js/quote-props': ['error', 'as-needed'],
+        'padding-line-between-statements': [
+          'error',
+          { blankLine: 'always', prev: '*', next: 'return' }
+        ]
       }
     }
   )


### PR DESCRIPTION
## Summary
- enforce blank lines before `return` statements via `padding-line-between-statements`

## Testing
- `pnpm install --frozen-lockfile`
- `npx eslint .` *(fails: missing `@typescript-eslint` plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6853d534dae4832b887d0a5c2bb87e13